### PR TITLE
Fix JsonValue typing for objects w/o properties

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,13 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- JsonValue typing for object without properties
-
-## [0.1.2]
-
-### Improved
-
 - formatBytes: show unit when byte value is 0
+- JsonValue typing for object without properties
 
 ## [0.1.1]
 

--- a/changelog.md
+++ b/changelog.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
-## [0.1.3]
-
 ### Fixed
 
 - formatBytes: show unit when byte value is 0

--- a/changelog.md
+++ b/changelog.md
@@ -7,10 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
-### Fixed
+### Improved
 
 - formatBytes: show unit when byte value is 0
-- JsonValue typing for object without properties
+
+### Fixed
+
+- JsonValue typing for objects without properties
 
 ## [0.1.1]
 

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.1.3]
+
+### Fixed
+
+- JsonValue typing for object without properties
+
+## [0.1.2]
+
 ### Improved
 
 - formatBytes: show unit when byte value is 0

--- a/packages/utils/common/src/ts/JsonValue.ts
+++ b/packages/utils/common/src/ts/JsonValue.ts
@@ -2,13 +2,11 @@
  * This union mimics the types allowed in RFC 7159.
  * @see https://tools.ietf.org/html/rfc7159
  */
-export type JsonValue = {
-    [key in string | number]:
-        JsonValue
-        | Array<number | boolean | string | null | undefined | JsonValue>
-        | number
-        | boolean
-        | string
-        | null
-        | undefined;
-};
+export type JsonValue =
+    | string
+    | number
+    | boolean
+    | null
+    | undefined
+    | JsonValue[]
+    | {[key in string | number]: JsonValue};


### PR DESCRIPTION
Previous type only worked for objects with properties.
i.e. `const hello: JsonValue = 'hello'` was not considered a valid JsonValue.

# Def. of Done
- [x] Changes described in changelog.md 📝 
- [x] Automatic tests written 🧪
- [x] Manually tested 🧪
- [x] Good code style
- [x] Necessary migrate instructions added to migrate.md 🚀
- [x] No known issues
